### PR TITLE
Patched PipelineConfigurationParameter oneOf to anyOf

### DIFF
--- a/swagger/openapi_public.yaml
+++ b/swagger/openapi_public.yaml
@@ -15505,10 +15505,10 @@ components:
             $ref: '#/components/schemas/PipelineConfigurationParameter'
     Settings:
       type: object
-      description: "This object contains a \"oneOf\" construct. Depending on which\
+      description: "This object contains a \"anyOf\" construct. Depending on which\
         \ type, you will receive a StringSettings-, IntegerSettings or OptionsSettings\
         \ object."
-      oneOf:
+      anyOf:
       - $ref: '#/components/schemas/StringSettings'
       - $ref: '#/components/schemas/IntegerSettings'
       - $ref: '#/components/schemas/OptionSettings'


### PR DESCRIPTION
* The PipelineConfigurationParameter Settings originally defines
  oneOf the Settings. But the actual server backend response otherwise.
  We have previously able to hot patch at generated SDK code. However,
  with the new Pydantic-based generator, this has to be patched at
  OpenAPI doc prior SDK code generation.
* See user story #129
