### PR TITLE
Added v3 SDK example - Create Nextflow Pipeline

### DIFF
--- a/examples/v3/create_nextflow_pipeline.py
+++ b/examples/v3/create_nextflow_pipeline.py
@@ -1,0 +1,99 @@
+"""
+Nextflow example from ICA doc:
+    Nextflow: Scatter-gather Method
+    https://help.ica.illumina.com/tutorials/nextflow/scatter-gather-nextflow
+
+
+Usage:
+    export ICAV2_ACCESS_TOKEN=$(icav2 tokens create)
+    cd examples/v3
+    python create_nextflow_pipeline.py
+
+Check:
+    You can check the example Nextflow pipeline created using this way via CLI as follows
+        icav2 projects enter 'development'
+        icav2 projectpipelines list | grep libica
+"""
+
+import os
+import uuid
+from importlib.metadata import version
+from pathlib import Path
+
+from libica.openapi.v3 import Configuration, ApiClient, ApiException, ProjectPipelineApi
+
+configuration = Configuration(
+    host="https://ica.illumina.com/ica/rest",
+    access_token=os.environ['ICAV2_ACCESS_TOKEN'],
+)
+# configuration.debug = True  # uncomment to debug API call logging
+
+if __name__ == '__main__':
+
+    print(f"libica-{version('libica')}")
+    print("-" * 64)
+
+    project_id = "ea19a3f5-ec7c-4940-a474-c31cd91dbad4"  # icav2 projects list
+    analysis_storage_id = "6e1b6c8f-f913-48b2-9bd0-7fc13eda0fd0"  # icav2 analysisstorages list
+
+    workflow_package = "nextflow-scatter-gather__1677025399"
+
+    workflow_files = [
+        workflow_file
+        for workflow_file in (Path(workflow_package)).rglob("*")
+        if workflow_file.is_file()
+    ]
+
+    workflow_file = list(filter(lambda x: x.name == "main.nf", workflow_files))[0]
+    params_xml_file = list(filter(lambda x: x.name == "params.xml", workflow_files))[0]
+    tool_files = list(filter(lambda x: x.name not in ["main.nf", "params.xml"], workflow_files))
+
+    relative_dir_fd = os.open(str(Path(workflow_package)), os.O_RDONLY)
+
+
+    def nf_file_opener(nf_file_path, flags):
+        return os.open(nf_file_path, flags, dir_fd=relative_dir_fd)
+
+
+    with ApiClient(configuration) as api_client:
+        api_instance = ProjectPipelineApi(api_client)
+
+        code = f"libica__{workflow_package.replace('.', '-')}__{str(uuid.uuid4())}"
+        description = "Testing create Nextflow Pipeline using libica v3"
+
+        parameters_xml_file = open(params_xml_file.relative_to(Path(workflow_package)), "rb", opener=nf_file_opener)
+
+        main_nf_file = open(workflow_file.relative_to(Path(workflow_package)), "rb", opener=nf_file_opener)
+
+        tool_nf_files = []
+        for tool_file in tool_files:
+            file_instance = open(tool_file.relative_to(Path(workflow_package)), "rb", opener=nf_file_opener)
+            tool_nf_files.append((file_instance.name, file_instance.read()))
+
+        # In v3 SDK, basically we need to prepare the data structure such that
+        #
+        #       tuple("params.xml", bytes<FileContent>)
+        #       tuple("main.nf", bytes<FileContent>)
+        #       [tuple("tools/my_tool.nf", bytes<FileContent>)]
+        #
+        # Uncomment the following to debug / observe
+        #
+        # print((parameters_xml_file.name, parameters_xml_file.read()))
+        # print((main_nf_file.name, main_nf_file.read()))
+        # print(tool_nf_files)
+
+        try:
+            api_response = api_instance.create_nextflow_pipeline(
+                project_id=project_id,
+                analysis_storage_id=analysis_storage_id,
+                code=code,
+                description=description,
+                parameters_xml_file=(parameters_xml_file.name, parameters_xml_file.read()),
+                main_nextflow_file=(main_nf_file.name, main_nf_file.read()),
+                other_nextflow_files=tool_nf_files,
+            )
+
+            print(api_response)
+
+        except ApiException as e:
+            raise ValueError("Exception when calling ProjectPipelineApi->create_nextflow_pipeline: %s\n" % e)

--- a/examples/v3/nextflow-scatter-gather__1677025399/main.nf
+++ b/examples/v3/nextflow-scatter-gather__1677025399/main.nf
@@ -1,0 +1,15 @@
+nextflow.enable.dsl=2
+
+include { sort } from 'tools/sort.nf'
+include { split } from 'tools/split.nf'
+include { merge } from 'tools/merge.nf'
+
+
+params.myinput = "test.test"
+
+workflow {
+    input_ch = Channel.fromPath(params.myinput)
+    split(input_ch)
+    sort(split.out.flatten())
+    merge(sort.out.collect())
+}

--- a/examples/v3/nextflow-scatter-gather__1677025399/params.xml
+++ b/examples/v3/nextflow-scatter-gather__1677025399/params.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pd:pipeline xmlns:pd="xsd://www.illumina.com/ica/cp/pipelinedefinition" code="" version="1.0">
+    <pd:dataInputs>
+        <pd:dataInput code="myinput" format="TSV" type="FILE" required="true" multiValue="false">
+            <pd:label>myinput</pd:label>
+            <pd:description></pd:description>
+        </pd:dataInput>
+    </pd:dataInputs>
+    <pd:steps/>
+</pd:pipeline>

--- a/examples/v3/nextflow-scatter-gather__1677025399/tools/merge.nf
+++ b/examples/v3/nextflow-scatter-gather__1677025399/tools/merge.nf
@@ -1,0 +1,18 @@
+process merge {
+    container 'public.ecr.aws/lts/ubuntu:22.04'
+    pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-small'
+    cpus 1
+    memory '512 MB'
+
+    publishDir 'out', mode: 'symlink'
+
+    input:
+    path x
+
+    output:
+    path 'merged.tsv'
+
+    """
+    cat $x > merged.tsv
+    """
+}

--- a/examples/v3/nextflow-scatter-gather__1677025399/tools/sort.nf
+++ b/examples/v3/nextflow-scatter-gather__1677025399/tools/sort.nf
@@ -1,0 +1,16 @@
+process sort {
+    container 'public.ecr.aws/lts/ubuntu:22.04'
+    pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-small'
+    cpus 1
+    memory '512 MB'
+
+    input:
+    path x
+
+    output:
+    path '*.sorted.tsv'
+
+    """
+    sort -gk1,1 $x > ${x.baseName}.sorted.tsv
+    """
+}

--- a/examples/v3/nextflow-scatter-gather__1677025399/tools/split.nf
+++ b/examples/v3/nextflow-scatter-gather__1677025399/tools/split.nf
@@ -1,0 +1,16 @@
+process split {
+    container 'public.ecr.aws/lts/ubuntu:22.04'
+    pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-small'
+    cpus 1
+    memory '512 MB'
+
+    input:
+    path x
+
+    output:
+    path("split.*.tsv")
+
+    """
+    split -a10 -d -l3 --numeric-suffixes=1 --additional-suffix .tsv ${x} split.
+    """
+}


### PR DESCRIPTION
* Added v3 SDK example on how to `create_nextflow_pipeline.py` a script using
  a simple Scatter-gather Nextflow example from ICA documentation.
* This example shows the hierarchy folder structure for Nextflow tools files at
  the remote ICA Flow workflow execution engine.
