### PR TITLE
Updated README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+3.0
+-----
+* Release date: 2025-06-06
+* Made the major SDK v3 update with Pydantic-based Python code generator.
+* Retained SDK v2 package as Long-term support (LTS) maintenance mode.
+* Deprecated ICA v1 packages.
+* Updated for upstream ICA API Release -- [2025 June 02 - ICA v2.36.0](https://help.ica.illumina.com/reference/software-release-notes/2025)
+* See [milestone 3.0 for all related PRs](https://github.com/umccr/libica/milestone/12?closed=1)
+
 2.5.0
 -----
 * Release date: 2024-07-31

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ pip install libica
 - See [changelog](https://github.com/umccr/libica/blob/main/CHANGELOG.md) and [closed milestones](https://github.com/umccr/libica/milestones?state=closed)
 - See opening [milestones](https://github.com/umccr/libica/milestones) for current planning and next SDK release
 
+## Release
+
+There are two SDK Python packages, namely `v2` and `v3`. If you are a new starter, please use `v3` SDK package. If you are an existing user, please upgrade to `v3` when you can. Most of the time, this should be straight forward with minor tuning to application code. Since `v3` release, the SDK `v2` package now enter into maintenance mode and deprecate by 2026 Oct.
+
 ## Example
 
 - See [examples](https://github.com/umccr/libica/tree/main/examples) directory for some example scripts

--- a/openapi/docs/index.md
+++ b/openapi/docs/index.md
@@ -6,12 +6,29 @@ Python SDK for Illumina Connected Analytics (ICA) -- https://umccr.github.io/lib
 - [Test Coverage](https://umccr.github.io/libica/coverage/)
 - [PyDoc](https://umccr.github.io/libica/libica/)
 
-#### SDK for ICA
+## Installation
+
+```commandline
+pip install libica
+```
+
+## SDK for ICA
 
 - [v2](v2)
+- [v3](v3)
 
-## License
+## Release
 
-MIT License and DISCLAIMER
+There are two SDK Python packages, namely `v2` and `v3`. If you are a new starter, please use `v3` SDK package. If you are an existing user, please upgrade to `v3` when you can. Most of the time, this should be straight forward with minor tuning to application code. Since `v3` release, the SDK `v2` package now enter into maintenance mode and deprecate by 2026 Oct.
+
+## Example
+
+- See [examples](https://github.com/umccr/libica/tree/main/examples) directory for some example scripts
+- See [wrapica](https://github.com/umccr/wrapica) and [icav2-cli-plugins](https://github.com/umccr/icav2-cli-plugins) for client application that build on top of SDK
+
+## Notice
+
+- MIT License and DISCLAIMER
+- [The Advanced Genomics Collaboration (TAGC)](https://www.tagcaustralia.com)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/openapi/mkdocs.yml
+++ b/openapi/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: libica
 nav:
   - v2: v2/README.md
+  - v3: v3/README.md
 
 theme:
   name:


### PR DESCRIPTION
3.0
-----
* Release date: 2025-06-06
* Made the major SDK v3 update with Pydantic-based Python code generator.
* Retained SDK v2 package as Long-term support (LTS) maintenance mode.
* Deprecated ICA v1 packages.
* Updated for upstream ICA API Release -- 2025 June 02 - ICA v2.36.0
